### PR TITLE
[FIX]: `cmake` not working after 4.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 if (WIN32)
     set(Boost_USE_STATIC_LIBS OFF)
@@ -12,6 +12,10 @@ endif( )
 
 # Define a single cmake project
 project(kenlm)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(FORCE_STATIC "Build static executables" OFF)
 option(COMPILE_TESTS "Compile tests" OFF)

--- a/python/BuildStandalone.cmake
+++ b/python/BuildStandalone.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 file(GLOB
   KENLM_PYTHON_STANDALONE_SRCS


### PR DESCRIPTION
I just updated the CMake minimum version required to make it build. It should fix this issue https://github.com/CAMeL-Lab/camel_tools/issues/155